### PR TITLE
Small fixes and text formatting

### DIFF
--- a/items/consumeables.lua
+++ b/items/consumeables.lua
@@ -531,7 +531,7 @@ SMODS.Consumable({
     },
     config = {chance = 100},
     loc_vars = function(self, info_queue, card)
-        return {vars = {G.game.probabilities.normal, (card.ability or self.config).chance}}
+        return {vars = {G.GAME.probabilities.normal, (card.ability or self.config).chance}}
     end,
 	
 	
@@ -542,7 +542,7 @@ SMODS.Consumable({
     cost = 4,
 
     use = function(self, card, area, copier)
-        if pseudorandom('yahimod_yahamouse') < (G.game.probabilities.normal / card.ability.chance) then
+        if pseudorandom('yahimod_yahamouse') < (G.GAME.probabilities.normal / card.ability.chance) then
             local card = create_card('Joker', G.Jokers, nil, nil, nil, nil, 'j_yahimod_yahicard', 'yahamouse')
             card:add_to_deck()
             G.jokers:emplace(card)
@@ -583,7 +583,7 @@ SMODS.Consumable({
     },
     config = {chance = 1000},
     loc_vars = function(self, info_queue, card)
-        return {vars = {G.game.probabilities.normal, (card.ability or self.config).chance}}
+        return {vars = {G.GAME.probabilities.normal, (card.ability or self.config).chance}}
     end,
 	
 	
@@ -594,7 +594,7 @@ SMODS.Consumable({
     cost = 4,
 
     use = function(self, card, area, copier)
-        if pseudorandom('yahimod_fortune') < (G.game.probabilities.normal / card.ability.chance) then
+        if pseudorandom('yahimod_fortune') < (G.GAME.probabilities.normal / card.ability.chance) then
             play_sound("yahimod_jackpot")
             ease_dollars(1000000)
         else

--- a/items/consumeables.lua
+++ b/items/consumeables.lua
@@ -525,10 +525,14 @@ SMODS.Consumable({
     loc_txt = {
         name = "is that yaha mouse",
         text={
-        "{C:green}1 in 100 chance",
+        "{C:green}#1# in #2# chance",
         "to spawn {C:attention}Yahiamice{}",
         },
     },
+    config = {chance = 100},
+    loc_vars = function(self, info_queue, card)
+        return {vars = {G.game.probabilities.normal, (card.ability or self.config).chance}}
+    end,
 	
 	
 	pos = {x=2, y= 2},
@@ -538,7 +542,7 @@ SMODS.Consumable({
     cost = 4,
 
     use = function(self, card, area, copier)
-        if math.random(1,100) == 1 then
+        if pseudorandom('yahimod_yahamouse') < (G.game.probabilities.normal / card.ability.chance) then
             local card = create_card('Joker', G.Jokers, nil, nil, nil, nil, 'j_yahimod_yahicard', 'yahamouse')
             card:add_to_deck()
             G.jokers:emplace(card)
@@ -573,10 +577,14 @@ SMODS.Consumable({
     loc_txt = {
         name = "Fortune Of Wheel",
         text={
-        "{C:green}1 in 1000 chance",
+        "{C:green}#1# in #2# chance",
         "to gain {C:attention}$1,000,000{}",
         },
     },
+    config = {chance = 1000},
+    loc_vars = function(self, info_queue, card)
+        return {vars = {G.game.probabilities.normal, (card.ability or self.config).chance}}
+    end,
 	
 	
 	pos = {x=3, y= 2},
@@ -586,7 +594,7 @@ SMODS.Consumable({
     cost = 4,
 
     use = function(self, card, area, copier)
-        if math.random(1,1000) == 1 then
+        if pseudorandom('yahimod_fortune') < (G.game.probabilities.normal / card.ability.chance) then
             play_sound("yahimod_jackpot")
             ease_dollars(1000000)
         else

--- a/items/consumeables.lua
+++ b/items/consumeables.lua
@@ -548,7 +548,23 @@ SMODS.Consumable({
             G.jokers:emplace(card)
             play_sound("yahimod_jackpot")
         else
-            return{message = "Nope!"}
+            -- copied from wheel of fortune
+            G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.4, func = function()
+                attention_text({
+                    text = localize('k_nope_ex'),
+                    scale = 1.3, 
+                    hold = 1.4,
+                    major = card,
+                    backdrop_colour = G.C.SECONDARY_SET.Tarot,
+                    align = (G.STATE == G.STATES.TAROT_PACK or G.STATE == G.STATES.SPECTRAL_PACK) and 'tm' or 'cm',
+                    offset = {x = 0, y = (G.STATE == G.STATES.TAROT_PACK or G.STATE == G.STATES.SPECTRAL_PACK) and -0.2 or 0},
+                    silent = true
+                    })
+                    G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.06*G.SETTINGS.GAMESPEED, blockable = false, blocking = false, func = function()
+                        play_sound('tarot2', 0.76, 0.4);return true end}))
+                    play_sound('tarot2', 1, 0.4)
+                    card:juice_up(0.3, 0.5)
+            return true end }))
         end
     end,
 
@@ -598,7 +614,22 @@ SMODS.Consumable({
             play_sound("yahimod_jackpot")
             ease_dollars(1000000)
         else
-            return{message = "Nope!"}
+            G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.4, func = function()
+                attention_text({
+                    text = localize('k_nope_ex'),
+                    scale = 1.3, 
+                    hold = 1.4,
+                    major = card,
+                    backdrop_colour = G.C.SECONDARY_SET.Tarot,
+                    align = (G.STATE == G.STATES.TAROT_PACK or G.STATE == G.STATES.SPECTRAL_PACK) and 'tm' or 'cm',
+                    offset = {x = 0, y = (G.STATE == G.STATES.TAROT_PACK or G.STATE == G.STATES.SPECTRAL_PACK) and -0.2 or 0},
+                    silent = true
+                    })
+                    G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.06*G.SETTINGS.GAMESPEED, blockable = false, blocking = false, func = function()
+                        play_sound('tarot2', 0.76, 0.4);return true end}))
+                    play_sound('tarot2', 1, 0.4)
+                    card:juice_up(0.3, 0.5)
+            return true end }))
         end
     end,
 

--- a/items/jokers.lua
+++ b/items/jokers.lua
@@ -2727,7 +2727,7 @@ SMODS.Joker{
     if context.joker_main then
         return {
             color = G.C.BLUE,
-            message = "+".. card.ability.extra.perfollow,
+            message = "+".. card.ability.extra.followercount,
             chip_mod = card.ability.extra.followercount
         }
     end
@@ -3359,6 +3359,10 @@ SMODS.Joker{
                 sound = "slice1",
                 }
             end
+        elseif context.joker_main then
+            return {
+                mult = card.ability.extra.multtotal
+            }
         end
     end,
 

--- a/items/jokers.lua
+++ b/items/jokers.lua
@@ -1065,7 +1065,7 @@ SMODS.Joker{
         name = 'Sisyphean Joker',
         text = { "Gains {X:mult,C:white} X#2#{} Mult",
                     "every round",
-                    "{C:green}1 in 4{} chance to reset",
+                    "{C:green}#3# in #4#{} chance to reset",
                     "back to {X:mult,C:white}X1{} Mult",
                     "{C:inactive}(Currently {X:mult,C:white}X#1#{C:inactive} Mult)",}
     },
@@ -1081,10 +1081,10 @@ SMODS.Joker{
     perishable_compat = false,
 
     pos = {x=0, y= 0},
-    config = { extra = {xmult = 1.5, additional = 0.5}},
+    config = { extra = {xmult = 1.5, additional = 0.5, chance = 4}},
 
     loc_vars = function(self, info_queue, center)
-		return { vars = { center.ability.extra.xmult, center.ability.extra.additional }  }
+		return { vars = { center.ability.extra.xmult, center.ability.extra.additional, G.game.probabilities.normal, center.ability.extra.chance }  }
 	end,
 
     calculate = function(self, card, context)
@@ -1095,7 +1095,7 @@ SMODS.Joker{
 			}
         end
         if context.setting_blind then
-            if math.random(4) ~= 1 then
+            if pseudorandom('sisyphus') < (G.game.probabilities.normal / card.ability.extra.chance) then
                 card.ability.extra.xmult = card.ability.extra.xmult + card.ability.extra.additional
                 return {
                     message = "Upgrade!",
@@ -2466,7 +2466,7 @@ SMODS.Joker{
     loc_txt= {
         name = 'Dame Dane',
         text = { "{C:red}+#1#{} mult",
-                    "{C:green}1 in 6{} chance",
+                    "{C:green}#2# in #3#{} chance",
                     "to crash the game"}
     },
     atlas = 'damedane',
@@ -2482,10 +2482,10 @@ SMODS.Joker{
     perishable_compat = false,
 
     pos = {x=0, y= 0},
-    config = { extra = {mult = 20}},
+    config = { extra = {mult = 20, chance = 6}},
     
     loc_vars = function(self, info_queue, center)
-		return { vars = { center.ability.extra.mult}  }
+		return { vars = { center.ability.extra.mult, G.game.probabilities.normal, center.ability.extra.chance }  }
 	end,
 
 
@@ -2576,7 +2576,7 @@ SMODS.Joker{
     loc_txt= {
         name = 'Adobe Premiere',
         text = { "{X:mult,C:white}X#1#{} mult",
-                    "{C:green}1 in 6{} chance",
+                    "{C:green}#2# in #3#{} chance",
                     "to crash the game"}
     },
     atlas = 'adobepremiere',
@@ -2593,16 +2593,16 @@ SMODS.Joker{
     perishable_compat = false,
 
     pos = {x=0, y= 0},
-    config = { extra = {xmult = 2}},
+    config = { extra = {xmult = 2, chance=6}},
     
     loc_vars = function(self, info_queue, center)
-		return { vars = { center.ability.extra.xmult}  }
+		return { vars = { center.ability.extra.xmult, G.game.probabilities.normal, center.ability.extra.chance}  }
 	end,
 
 
     calculate = function(self, card, context)
     if context.joker_main then
-        if math.random(1,6) == 1 then crashGame() end
+        if pseudorandom('adobepremiere') < (G.game.probabilities.normal / card.ability.extra.chance) then crashGame() end
         return {
             color = G.C.RED,
             message = "x".. card.ability.extra.xmult,
@@ -4475,7 +4475,7 @@ SMODS.Joker{
     loc_txt= {
         name = 'Worn Down Gaming Chair',
         text = { "{C:blue}+#1#{} chips and {C:red}+#2#{} Mult",
-                    "{C:green}1 in 4{} chance to break down",
+                    "{C:green}#3# in 4{} chance to break down",
                     "when blind is selected",}
     },
     atlas = 'schmeebchair',
@@ -4491,15 +4491,15 @@ SMODS.Joker{
     perishable_compat = false,
 
     pos = {x=0, y= 0},
-    config = { extra = {chips = 10, mult = 2}},
+    config = { extra = {chips = 10, mult = 2, chance = 4}},
 
     loc_vars = function(self, info_queue, center)
-		return { vars = { center.ability.extra.chips, center.ability.extra.mult }  }
+		return { vars = { center.ability.extra.chips, center.ability.extra.mult, G.game.probabilities.normal }  }
 	end,
     
     calculate = function(self, card, context)
         if context.setting_blind then
-            if math.random(1,4) == 1 then
+            if pseudorandom('schmeebchair') < (G.GAME.probabilities.normal / card.ability.extra.chance) then
                 explodeCard(card)
             end
         end

--- a/items/jokers.lua
+++ b/items/jokers.lua
@@ -2723,7 +2723,7 @@ SMODS.Joker{
 
     calculate = function(self, card, context)
     recheckTwitch()
-    card.ability.extra.followercount = G.yahifollowers * math.floor(card.ability.extra.perfollow/1000)
+    card.ability.extra.followercount = math.floor(G.yahifollowers * card.ability.extra.perfollow / 1000)
     if context.joker_main then
         return {
             color = G.C.BLUE,

--- a/items/jokers.lua
+++ b/items/jokers.lua
@@ -1084,7 +1084,7 @@ SMODS.Joker{
     config = { extra = {xmult = 1.5, additional = 0.5, chance = 4}},
 
     loc_vars = function(self, info_queue, center)
-		return { vars = { center.ability.extra.xmult, center.ability.extra.additional, G.game.probabilities.normal, center.ability.extra.chance }  }
+		return { vars = { center.ability.extra.xmult, center.ability.extra.additional, G.GAME.probabilities.normal, center.ability.extra.chance }  }
 	end,
 
     calculate = function(self, card, context)
@@ -1095,7 +1095,7 @@ SMODS.Joker{
 			}
         end
         if context.setting_blind then
-            if pseudorandom('sisyphus') < (G.game.probabilities.normal / card.ability.extra.chance) then
+            if pseudorandom('sisyphus') < (G.GAME.probabilities.normal / card.ability.extra.chance) then
                 card.ability.extra.xmult = card.ability.extra.xmult + card.ability.extra.additional
                 return {
                     message = "Upgrade!",
@@ -2485,7 +2485,7 @@ SMODS.Joker{
     config = { extra = {mult = 20, chance = 6}},
     
     loc_vars = function(self, info_queue, center)
-		return { vars = { center.ability.extra.mult, G.game.probabilities.normal, center.ability.extra.chance }  }
+		return { vars = { center.ability.extra.mult, G.GAME.probabilities.normal, center.ability.extra.chance }  }
 	end,
 
 
@@ -2596,13 +2596,13 @@ SMODS.Joker{
     config = { extra = {xmult = 2, chance=6}},
     
     loc_vars = function(self, info_queue, center)
-		return { vars = { center.ability.extra.xmult, G.game.probabilities.normal, center.ability.extra.chance}  }
+		return { vars = { center.ability.extra.xmult, G.GAME.probabilities.normal, center.ability.extra.chance}  }
 	end,
 
 
     calculate = function(self, card, context)
     if context.joker_main then
-        if pseudorandom('adobepremiere') < (G.game.probabilities.normal / card.ability.extra.chance) then crashGame() end
+        if pseudorandom('adobepremiere') < (G.GAME.probabilities.normal / card.ability.extra.chance) then crashGame() end
         return {
             color = G.C.RED,
             message = "x".. card.ability.extra.xmult,
@@ -2714,7 +2714,7 @@ SMODS.Joker{
     perishable_compat = false,
 
     pos = {x=0, y= 0},
-    config = { extra = {perfollow = 1, followercount = G.yahifollowers/1000 }},
+    config = { extra = {perfollow = 1, followercount = math.floor(G.yahifollowers/1000) }},
     
     loc_vars = function(self, info_queue, center)
 		return { vars = { center.ability.extra.perfollow , center.ability.extra.followercount}  }
@@ -2723,7 +2723,7 @@ SMODS.Joker{
 
     calculate = function(self, card, context)
     recheckTwitch()
-    card.ability.extra.followercount = G.yahifollowers * card.ability.extra.perfollow/1000
+    card.ability.extra.followercount = G.yahifollowers * math.floor(card.ability.extra.perfollow/1000)
     if context.joker_main then
         return {
             color = G.C.BLUE,
@@ -4494,7 +4494,7 @@ SMODS.Joker{
     config = { extra = {chips = 10, mult = 2, chance = 4}},
 
     loc_vars = function(self, info_queue, center)
-		return { vars = { center.ability.extra.chips, center.ability.extra.mult, G.game.probabilities.normal }  }
+		return { vars = { center.ability.extra.chips, center.ability.extra.mult, G.GAME.probabilities.normal }  }
 	end,
     
     calculate = function(self, card, context)

--- a/items/jokers.lua
+++ b/items/jokers.lua
@@ -1065,9 +1065,9 @@ SMODS.Joker{
         name = 'Sisyphean Joker',
         text = { "Gains {X:mult,C:white} X#2#{} Mult",
                     "every round",
-                    "1 in 4 chance to reset",
+                    "{C:green}1 in 4{} chance to reset",
                     "back to {X:mult,C:white}X1{} Mult",
-                    "{C:inactive}(Currently {X:mult,C:white}X#1# {C:inactive}Mult)",}
+                    "{C:inactive}(Currently {X:mult,C:white}X#1#{C:inactive} Mult)",}
     },
     atlas = 'sisyphus',
     rarity = 2,
@@ -1555,7 +1555,7 @@ SMODS.Joker{
         text = { "{C:blue}+#1#{} Chips",
                     "for every {C:attention}vowel in the",
                     "name of the card to its right",
-                    "{C:inactive}Currently {C:blue}+#2#{} Chips",}
+                    "{C:inactive}Currently {C:blue}+#2#{C:inactive} Chips",}
     },
     atlas = 'leo',
     rarity = 2,
@@ -1855,7 +1855,7 @@ SMODS.Joker{
         text = { "{X:mult,C:white}X#1#{} Mult",
                     "for every {C:attention}cat joker",
                     "in your possession",
-                    "Currently {X:mult,C:white}X#2#{} Mult",}
+                    "{C:inactive}Currently {X:mult,C:white}X#2#{C:inactive} Mult",}
     },
     atlas = 'joel',
     rarity = 2,
@@ -2112,7 +2112,7 @@ SMODS.Joker{
                     "Sets your shop slots to {C:attention}9",
                     "The more you reroll, the more likely",
                     "{C:dark_edition}Negative{} cards show up",
-                    "{C:inactive}(Currently{} {C:dark_edition}#2#% odds)",
+                    "{C:inactive}(Currently{} {C:dark_edition}#2#%{C:inactive} odds)",
     },},
     atlas = 'yahicard',
     rarity = 4,
@@ -2393,7 +2393,7 @@ SMODS.Joker{
         text = { "Earn {C:attention}$#1#{} at end of round",
                     "if your jokers are ordered by",
                     "name length (shortest to longest)",
-                    "{C:inactive}Currently{} #2#"}
+                    "{C:inactive}Currently #2#"}
     },
     atlas = 'ocd',
     rarity = 2,
@@ -2466,7 +2466,7 @@ SMODS.Joker{
     loc_txt= {
         name = 'Dame Dane',
         text = { "{C:red}+#1#{} mult",
-                    "1 in 6{} chance",
+                    "{C:green}1 in 6{} chance",
                     "to crash the game"}
     },
     atlas = 'damedane',
@@ -2576,7 +2576,7 @@ SMODS.Joker{
     loc_txt= {
         name = 'Adobe Premiere',
         text = { "{X:mult,C:white}X#1#{} mult",
-                    "1 in 6{} chance",
+                    "{C:green}1 in 6{} chance",
                     "to crash the game"}
     },
     atlas = 'adobepremiere',
@@ -2756,7 +2756,7 @@ SMODS.Joker{
         text = { "{C:red}+#1#{} Mult for every 5",
                     "viewers currently watching",
                     "{C:attention}Yahiamice on {C:dark_edition}Twitch",
-                    "{C:inactive}Currently {C:red}+#2#{} Mult"}
+                    "{C:inactive}Currently {C:red}+#2#{C:inactive} Mult"}
     },
     atlas = 'twitchstream',
     rarity = 3,
@@ -2809,7 +2809,7 @@ SMODS.Joker{
                 "when {C:attention}Blind{} is selected, and adds",
                 "half its {C:attention}sell value{} to this",
                 "Joker's end-of-round payout",
-                "({C:inactive}Currently {C:attention}$#1#)"}
+                "{C:inactive}(Currently {C:attention}$#1#{C:inactive})"}
     },
     atlas = 'blingblingbear',
     rarity = 3,
@@ -4921,7 +4921,7 @@ SMODS.Joker{
     key = 'mimearon',
     loc_txt= {
         name = 'Mimaron',
-        text = { "All Red Seal Steel Kings",
+        text = { "All {C:attention}Red Seal Steel Kings{}",
                     "held in hand grant {X:mult,C:white}X#1#{} Mult",}
     },
     atlas = 'mimearon',

--- a/items/seals.lua
+++ b/items/seals.lua
@@ -161,13 +161,13 @@ SMODS.Seal {
         name = 'iFunny watermark',
         text = {
             'Retriggers once',
-            '{C:green}1 in 3{} chance to',
+            '{C:green}#1# in 3{} chance to',
             'crop watermark out',
         }
     },
 
     loc_vars = function(self, info_queue)
-        return { vars = {self.config.mult, self.config.chips, self.config.money, self.config.x_mult, } }
+        return { vars = {G.game.probabilities.normal, self.config.mult, self.config.chips, self.config.money, self.config.x_mult, } }
     end,
     atlas = "ifunny_seal",
     pos = {x=0, y=0},
@@ -179,7 +179,7 @@ SMODS.Seal {
 
                 repetitions = 1,
                 G.E_MANAGER:add_event(Event({func = function()
-                if math.random(1,3) == 1 then 
+                if pseudorandom('ifunny') < (G.GAME.probabilities.normal / 3) then 
                     card.seal = nil 
                     card_eval_status_text(card,'extra',nil,nil,nil,{message = "Cropped!"})
                     play_sound("cardFan2")

--- a/items/seals.lua
+++ b/items/seals.lua
@@ -167,7 +167,7 @@ SMODS.Seal {
     },
 
     loc_vars = function(self, info_queue)
-        return { vars = {G.game.probabilities.normal, self.config.mult, self.config.chips, self.config.money, self.config.x_mult, } }
+        return { vars = {G.GAME.probabilities.normal, self.config.mult, self.config.chips, self.config.money, self.config.x_mult, } }
     end,
     atlas = "ifunny_seal",
     pos = {x=0, y=0},


### PR DESCRIPTION
Noticed a few things while playing that seemed easy enough to fix, so I threw together a PR

- Katana wouldn't actually give you any mult during scoring
- Fixed 'Twitch Chat' so it displays the correct value during scoring (Would always show "+1 Chips" before)
- Changed any card with probability effects to use the probability system, so cards like 'Oops! All 6s' now affect them
- Made the 'Nope!' message appear on 'is that yaha mouse' and 'Fortune of Wheel'
- Fixed some minor formatting issues with Joker descriptions

Let me know if any of these were intentional - it all seems fair game, but I don't want to accidentally remove a joke that was there on purpose.

## Joker Formatting Changes:
Before -> After
(The 0% in Yahiamice is still formatted, I just took a screenshot at a bad time when it looked grey)
![image](https://github.com/user-attachments/assets/2a098eac-405f-4c2c-81c4-9571e24f8372) | ![image](https://github.com/user-attachments/assets/935fe874-1fe6-4c4b-b62b-1b28a8c7dd50)

