### PR TITLE
Fix Twitch cards crashing game/game not starting if the game is offline or Twitch is inaccessible.

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -58,6 +58,8 @@ G.last_update_time = 0
 function recheckTwitch(please)
 
     if ((os.time() - G.last_update_time) >= 90) or please == "please" then
+        G.yahiviewers = 0
+        G.yahifollowers = 111000
         G.last_update_time = os.time()
         local json = require "json"
         local succ, https = pcall(require, "SMODS.https")
@@ -75,9 +77,6 @@ function recheckTwitch(please)
         local status, body, headers = https.request(url, options)
         if status ~= 200 then
             print("Can't connect to Twitch! Are you offline? Is Twitch being blocked by a firewall?")
-            G.yahiviewers = 0
-            G.yahifollowers = 111000
-            G.twitchfunctionality = false
         else
             G.twitchbodyjson = json.decode(body)
             G.yahifollowers = G.twitchbodyjson[1].data.user.followers.totalCount

--- a/core.lua
+++ b/core.lua
@@ -58,8 +58,6 @@ G.last_update_time = 0
 function recheckTwitch(please)
 
     if ((os.time() - G.last_update_time) >= 90) or please == "please" then
-        G.yahiviewers = 0
-        G.yahifollowers = 111000
         G.last_update_time = os.time()
         local json = require "json"
         local succ, https = pcall(require, "SMODS.https")
@@ -77,6 +75,8 @@ function recheckTwitch(please)
         local status, body, headers = https.request(url, options)
         if status ~= 200 then
             print("Can't connect to Twitch! Are you offline? Is Twitch being blocked by a firewall?")
+            G.yahiviewers = 0
+            G.yahifollowers = 111000
         else
             G.twitchbodyjson = json.decode(body)
             G.yahifollowers = G.twitchbodyjson[1].data.user.followers.totalCount

--- a/core.lua
+++ b/core.lua
@@ -73,13 +73,20 @@ function recheckTwitch(please)
         }
 
         local status, body, headers = https.request(url, options)
-        G.twitchbodyjson = json.decode(body)
-        G.yahifollowers = G.twitchbodyjson[1].data.user.followers.totalCount
-        G.yahiviewers = 0
-        if G.twitchbodyjson[1].data.user.stream then G.yahiviewers = G.twitchbodyjson[1].data.user.stream.viewersCount else print("Failed to parse yahi's viewer count! Maybe he's offline?") end
+        if status ~= 200 then
+            print("Can't connect to Twitch! Are you offline? Is Twitch being blocked by a firewall?")
+            G.yahiviewers = 0
+            G.yahifollowers = 111000
+            G.twitchfunctionality = false
+        else
+            G.twitchbodyjson = json.decode(body)
+            G.yahifollowers = G.twitchbodyjson[1].data.user.followers.totalCount
+            G.yahiviewers = 0
+            if G.twitchbodyjson[1].data.user.stream then G.yahiviewers = G.twitchbodyjson[1].data.user.stream.viewersCount else print("Failed to parse yahi's viewer count! Maybe he's offline?") end
+        end
     else
-		--print("Can't update! Wait " .. (90 - (os.time() - G.last_update_time)) .. " more seconds please...")
-	end
+        --print("Can't update! Wait " .. (90 - (os.time() - G.last_update_time)) .. " more seconds please...")
+    end
 end
 
 


### PR DESCRIPTION
I tried playing Balatro with the yahimod installed in school today, and my game wasn't loading. On closer inspection, I noticed that it was because it was trying to read the HTTPS request data, but the request data didn't exist since requests to Twitch were being blocked by my schools firewall. After testing, I also realised the same thing happens if you try launching the game offline.

My modifications to the code make it so the follower card sets the followers to the current amount he has (~111K) and viewers to 0 if Twitch cannot be reached.